### PR TITLE
Fix CORS wildcard

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -65,6 +65,7 @@ With your actual Railway URL.
 2. Add your Vercel domain to the CORS origins
 3. Set environment variable:
    - `CORS_ORIGINS`: `https://your-vercel-app.vercel.app,http://localhost:3000`
+   - Avoid wildcard origins when `allow_credentials` is enabled
 
 ## Step 6: Test Your Deployment
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm run dev
 Backend (`.env`):
 ```
 PORT=8001
+# Comma-separated list of allowed origins (no wildcards)
 CORS_ORIGINS=http://localhost:3000,https://yourdomain.com
 ```
 

--- a/backend/app/utils/config.py
+++ b/backend/app/utils/config.py
@@ -1,8 +1,6 @@
-import os
 from typing import Optional
 from pydantic_settings import BaseSettings
 from functools import lru_cache
-
 
 class Settings(BaseSettings):
     # API Configuration

--- a/backend/app/utils/config.py
+++ b/backend/app/utils/config.py
@@ -20,8 +20,7 @@ class Settings(BaseSettings):
         "http://localhost:3000", 
         "http://localhost:5173",
         "https://*.vercel.app",
-        "https://rhymeslikedimes.vercel.app",
-        "*"  # Allow all origins for now
+        "https://rhymeslikedimes.vercel.app"
     ]
     
     # Redis Configuration (optional)


### PR DESCRIPTION
## Summary
- remove `"*"` wildcard from CORS origins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datamuse')*

------
https://chatgpt.com/codex/tasks/task_e_686b592cf1248331b2d2eeff1c0dd1e0