### PR TITLE
Remove unused libs from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ npm run dev
 - **FastAPI** - Modern Python web framework
 - **Datamuse API** - Comprehensive word-finding engine
 - **Pronouncing** - CMU dictionary interface
-- **Phyme** - Advanced rhyming patterns
 - **WebSocket** - Real-time communication
 
 ### Frontend

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,14 +2,11 @@ fastapi==0.109.0
 uvicorn[standard]==0.27.0
 python-datamuse==2.0.1
 pronouncing==0.2.0
-Phyme==0.0.9
-SoundsLike==0.0.11
 pydantic==2.5.3
 pydantic-settings==2.1.0
 python-multipart==0.0.6
 websockets==12.0
 httpx==0.26.0
-redis==5.0.1
 python-dotenv==1.0.0
 pytest==7.4.4
 pytest-asyncio==0.23.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,9 @@ fastapi==0.109.0
 uvicorn[standard]==0.27.0
 python-datamuse==2.0.1
 pronouncing==0.2.0
-Phyme==0.0.9
-SoundsLike==0.0.11
 pydantic==2.5.3
 pydantic-settings==2.1.0
 python-multipart==0.0.6
 websockets==12.0
 httpx==0.26.0
-redis==5.0.1
 python-dotenv==1.0.0


### PR DESCRIPTION
## Summary
- drop `Phyme`, `SoundsLike`, and `redis` from dependency lists
- remove mention of Phyme in the README

## Testing
- `pytest -q` *(fails: fixture 'phrase1' not found; 1 failure, 1 error)*
- `python main.py` *(app starts and logs that Phyme is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_686b592fda748331a1da597b7b79b458