### PR TITLE
Fix SuggestionPanel React import

### DIFF
--- a/frontend/src/components/SuggestionPanel.tsx
+++ b/frontend/src/components/SuggestionPanel.tsx
@@ -1,4 +1,4 @@
-import { } from 'react';
+import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { RhymeInfo, RhymeType } from '../types';
 import { RhymeChip } from './RhymeChip';


### PR DESCRIPTION
## Summary
- ensure SuggestionPanel explicitly imports React for React.FC

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `python3 backend/test_rhyme_classification.py`

------
https://chatgpt.com/codex/tasks/task_e_686b5942c6608331a50268acb71cfc68