### PR TITLE
Remove unused asyncio import

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -1,7 +1,6 @@
 from fastapi import WebSocket, WebSocketDisconnect
 from typing import Dict, Set
 import json
-import asyncio
 import logging
 from app.core.rhyme_engine import RhymeEngine
 from app.utils.config import get_settings


### PR DESCRIPTION
## Summary
- clean up websocket endpoint by removing unused `asyncio` import

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686b596425488331b21785f9ef822d6d