### PR TITLE
Refine suggestion request payload

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,7 +1,10 @@
+import logging
+from typing import Optional
+
 from fastapi import APIRouter, HTTPException
+
 from app.models.schemas import AnalyzeRequest, AnalyzeResponse, SuggestionRequest
 from app.core.rhyme_engine import RhymeEngine
-import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -37,14 +40,16 @@ async def analyze_bar(request: AnalyzeRequest):
 
 
 @router.post("/suggestions/{word}")
-async def get_word_suggestions(word: str, request: SuggestionRequest):
+async def get_word_suggestions(word: str, request: Optional[SuggestionRequest] = None):
     """
     Get rhyme suggestions for a specific word.
     """
     try:
+        rhyme_type = request.rhyme_type if request and request.rhyme_type else "all"
+
         suggestions = rhyme_engine.get_suggestions_for_word(
             word,
-            rhyme_type=request.rhyme_type,
+            rhyme_type=rhyme_type,
             max_results=10
         )
         

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -24,8 +24,10 @@ class AnalyzeResponse(BaseModel):
 
 
 class SuggestionRequest(BaseModel):
-    word: str = Field(..., description="Single word to get suggestions for")
-    rhyme_type: Optional[str] = Field("all", description="Type of rhyme: perfect, near, slant, or all")
+    rhyme_type: Optional[str] = Field(
+        "all",
+        description="Type of rhyme: perfect, near, slant, or all"
+    )
 
 
 class WebSocketMessage(BaseModel):


### PR DESCRIPTION
## Summary
- simplify the suggestion request schema to only allow clients to request a rhyme type
- update the suggestions endpoint to rely on the URL path for the target word and default the rhyme type to "all"

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pkg_resources')*


------
https://chatgpt.com/codex/tasks/task_e_68db5bacce608331acefe8366702a983