### PR TITLE
Allow Vercel preview origins via CORS regex

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
+    allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/utils/config.py
+++ b/backend/app/utils/config.py
@@ -15,11 +15,11 @@ class Settings(BaseSettings):
     
     # CORS Configuration
     cors_origins: list = [
-        "http://localhost:3000", 
+        "http://localhost:3000",
         "http://localhost:5173",
-        "https://*.vercel.app",
         "https://rhymeslikedimes.vercel.app"
     ]
+    cors_origin_regex: Optional[str] = r"https://[a-zA-Z0-9-]+\.vercel\.app"
     
     # Redis Configuration (optional)
     redis_url: Optional[str] = None

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BACKEND_DIR))
+sys.path.append(str(BACKEND_DIR / "app"))
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _make_preflight_request(origin: str):
+    return client.options(
+        "/api/health",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Content-Type",
+        },
+    )
+
+
+def test_vercel_preview_origin_is_allowed():
+    preview_origin = "https://feature-123--rhymeslikedimes.vercel.app"
+    response = _make_preflight_request(preview_origin)
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == preview_origin
+
+
+def test_production_origin_remains_whitelisted():
+    production_origin = "https://rhymeslikedimes.vercel.app"
+    response = _make_preflight_request(production_origin)
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == production_origin


### PR DESCRIPTION
## Summary
- add a configurable CORS origin regex that matches Vercel preview subdomains while keeping explicit production origins
- wire the new regex into the FastAPI CORS middleware configuration
- add a regression test that exercises CORS preflight handling for preview and production domains

## Testing
- pytest backend/tests/test_cors.py

------
https://chatgpt.com/codex/tasks/task_e_68db5bb6ee84833190ed34ae1626ef6a