### PR TITLE
Switch frontend build configs to CommonJS exports

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -28,4 +28,4 @@ export default {
     },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- switch the PostCSS and Tailwind configuration files to CommonJS exports for consistency with the build tooling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db605135888331aea1c9a380a2cde3