### PR TITLE
Fix API URL suffix handling in useRhymes hook

### DIFF
--- a/frontend/src/hooks/useRhymes.ts
+++ b/frontend/src/hooks/useRhymes.ts
@@ -29,7 +29,11 @@ export const useRhymes = () => {
         : 'https://rhymeslikedimes-production.up.railway.app';
       const baseURL = (import.meta.env.VITE_API_URL as string | undefined) || defaultBaseURL;
       const normalizedBaseURL = baseURL.replace(/\/+$/, '');
-      const apiUrl = `${normalizedBaseURL}/api/analyze`;
+      const hasApiSuffix = /\/api$/i.test(normalizedBaseURL);
+      const apiPath = hasApiSuffix ? 'analyze' : 'api/analyze';
+      const apiUrl = normalizedBaseURL
+        ? `${normalizedBaseURL}/${apiPath}`
+        : `/${apiPath}`;
       
       if (import.meta.env.DEV) {
         console.debug('Making API request to:', apiUrl);


### PR DESCRIPTION
## Summary
- avoid appending an extra `/api` segment when the configured base URL already ends with `/api`
- keep development proxy behavior while normalizing trailing slashes for API requests

## Testing
- npm run build
- node -e "const computeUrl = (baseURL) => { const normalizedBaseURL = baseURL.replace(/\/+$/, ''); const hasApiSuffix = /\/api$/i.test(normalizedBaseURL); const apiPath = hasApiSuffix ? 'analyze' : 'api/analyze'; return normalizedBaseURL ? `${normalizedBaseURL}/${apiPath}` : `/${apiPath}`; }; ['', 'https://example.railway.app', 'https://example.railway.app/api'].forEach((base) => { console.log(base || \"<empty>\", '->', computeUrl(base)); });"

------
https://chatgpt.com/codex/tasks/task_e_68db63b7570c8331b6fc0dbe07cbc9d5