### PR TITLE
Fix API base URL normalization in useRhymes hook

### DIFF
--- a/frontend/src/hooks/useRhymes.ts
+++ b/frontend/src/hooks/useRhymes.ts
@@ -29,7 +29,17 @@ export const useRhymes = () => {
         : 'https://rhymeslikedimes-production.up.railway.app';
       const baseURL = (import.meta.env.VITE_API_URL as string | undefined) || defaultBaseURL;
       const normalizedBaseURL = baseURL.replace(/\/+$/, '');
-      const apiUrl = `${normalizedBaseURL}/api/analyze`;
+
+      let apiBase: string;
+      if (normalizedBaseURL === '') {
+        apiBase = '/api';
+      } else if (normalizedBaseURL.endsWith('/api')) {
+        apiBase = normalizedBaseURL;
+      } else {
+        apiBase = `${normalizedBaseURL}/api`;
+      }
+
+      const apiUrl = `${apiBase}/analyze`;
       
       if (import.meta.env.DEV) {
         console.debug('Making API request to:', apiUrl);


### PR DESCRIPTION
## Summary
- normalize configured API base URLs to avoid duplicating the /api path segment
- retain development proxy behaviour while ensuring trailing slashes are handled consistently

## Testing
- npm run build
- node <<'NODE'
const testBases = ['', 'https://example.up.railway.app', 'https://example.up.railway.app/api', 'https://example.up.railway.app/api/'];
for (const baseURL of testBases) {
  const normalizedBaseURL = baseURL.replace(/\/+$/, '');
  let apiBase;
  if (normalizedBaseURL === '') {
    apiBase = '/api';
  } else if (normalizedBaseURL.endsWith('/api')) {
    apiBase = normalizedBaseURL;
  } else {
    apiBase = `${normalizedBaseURL}/api`;
  }
  const apiUrl = `${apiBase}/analyze`;
  console.log(baseURL, '=>', apiUrl);
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68db63d047488331a473aeb0f988f608